### PR TITLE
fix: fix release workflow to wait for the correct job of the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,4 +268,5 @@ jobs:
           VAPP_VERSION: ${{ github.sha }}
           REPO: ghcr.io/${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}
         run: |
+          echo "Current hash: ${{ github.sha }}"
           docker buildx imagetools create -t $REPO/$VAPP_NAME:$VAPP_VERSION $REPO/$VAPP_NAME:$VAPP_VERSION-amd64 $REPO/$VAPP_NAME:$VAPP_VERSION-aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,9 @@ jobs:
         component: ${{ fromJson(needs.initialize-matrix.outputs.deployment-matrix) }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }} # ${{ github.actor }} ?
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: github-repository-name-case-adjusted
@@ -66,6 +66,17 @@ jobs:
         uses: ASzc/change-string-case-action@v1
         with:
           string: ${{ github.repository }}
+
+      - name: "${{ matrix.component.Name }} -- Publish release image to GHCR"
+        env:
+          VAPP_NAME: ${{ matrix.component.Name }}
+          COMMIT: ${{ github.sha }}
+          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
+          GIT_HUB_REPOSITORY_NAME_LOWER_CASE: ${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}
+          TARGET_REGISTRY: 'ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}' # Please use your target container registry
+        run: |
+          echo "Copy vApp image 'docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAPP_NAME:$COMMIT' to 'docker://$TARGET_REGISTRY/$VAPP_NAME:$VAPP_VERSION'"
+          skopeo copy --all  "docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAPP_NAME:$COMMIT" "docker://$TARGET_REGISTRY/$VAPP_NAME:$VAPP_VERSION"
 
   release-documentation:
     name: Generate release documentation
@@ -85,19 +96,22 @@ jobs:
         with:
           node-version: '14.x'
 
-      - uses: haya14busa/action-cond@v1
+      - name: Conditional input event value
+        uses: haya14busa/action-cond@v1
         id: condval
         with:
           cond: ${{ !github.event.inputs.name }}
           if_true: ${{ github.event.inputs.name }}
           if_false: ${{ github.sha }}
+      - name: Use conditional value
+        run: echo "Event = ${{ steps.condval.outputs.value }}"
 
-      - name: Wait for CI workflow
+      - name: Wait for CI workflow (Multi-Arch image)
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-CI
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "build-images"
+          checkName: "create-multiarch-image"
           ref:  ${{ steps.condval.outputs.value }}
           timeoutSeconds: 600
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
 
       - id: get_version
         uses: battila7/get-version-action@v2
+        run: |
+          echo "Current Hhash: ${{ github.sha }}"
+          echo "Inputs name: ${{ github.event.inputs.name }}"
 
       - run: echo "Using VehicleApp version ${{ steps.get_version.outputs.version-without-v }} from tag"
 
@@ -113,7 +116,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: "create-multiarch-image"
           ref:  ${{ steps.condval.outputs.value }}
-          timeoutSeconds: 600
+          timeoutSeconds: 120
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
 
       - id: get_version
         uses: battila7/get-version-action@v2
+
+      - name: Test values
         run: |
           echo "Current Hhash: ${{ github.sha }}"
           echo "Inputs name: ${{ github.event.inputs.name }}"


### PR DESCRIPTION
# Description

Fix release workflow to wait for the correct job of the CI workflow

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
