### PR TITLE
fix: adjust the dapr --runtime-version 1.8.1

### DIFF
--- a/.vscode/scripts/runtime/k3d/configure_controlplane.sh
+++ b/.vscode/scripts/runtime/k3d/configure_controlplane.sh
@@ -14,7 +14,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../../../.." )
-DAPR_RUNTIME=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.runtime | tr -d '"')
+DAPR_RUNTIME=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.runtime.version | tr -d '"')
 
 if ! k3d registry get k3d-registry.localhost &> /dev/null
 then

--- a/.vscode/scripts/runtime/k3d/configure_controlplane.sh
+++ b/.vscode/scripts/runtime/k3d/configure_controlplane.sh
@@ -14,6 +14,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../../../.." )
+DAPR_RUNTIME=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.runtime | tr -d '"')
 
 if ! k3d registry get k3d-registry.localhost &> /dev/null
 then
@@ -63,7 +64,7 @@ if ! dapr status -k &> /dev/null
 then
   # Init Dapr in cluster. The --runtime-version is used to specify the dapr runtime version (i.e. remove the '#')
   # Dapr runtime releases: https://github.com/dapr/dapr/releases
-  dapr init -k --wait --timeout 600 --runtime-version 1.8.0
+  dapr init -k --wait --timeout 600 --runtime-version $DAPR_RUNTIME
 
   # Apply Dapr config
   kubectl apply -f $ROOT_DIRECTORY/deploy/runtime/k3d/.dapr/config.yaml

--- a/.vscode/scripts/runtime/k3d/configure_controlplane.sh
+++ b/.vscode/scripts/runtime/k3d/configure_controlplane.sh
@@ -63,7 +63,7 @@ if ! dapr status -k &> /dev/null
 then
   # Init Dapr in cluster. The --runtime-version is used to specify the dapr runtime version (i.e. remove the '#')
   # Dapr runtime releases: https://github.com/dapr/dapr/releases
-  dapr init -k --wait --timeout 600 # --runtime-version 1.8.0-xyz
+  dapr init -k --wait --timeout 600 --runtime-version 1.8.0
 
   # Apply Dapr config
   kubectl apply -f $ROOT_DIRECTORY/deploy/runtime/k3d/.dapr/config.yaml

--- a/.vscode/scripts/runtime/k3d/configure_controlplane.sh
+++ b/.vscode/scripts/runtime/k3d/configure_controlplane.sh
@@ -61,8 +61,9 @@ fi
 
 if ! dapr status -k &> /dev/null
 then
-  # Init Dapr in cluster
-  dapr init -k --wait --timeout 600 --runtime-version 1.8.0-rc.3
+  # Init Dapr in cluster. The --runtime-version is used to specify the dapr runtime version (i.e. remove the '#')
+  # Dapr runtime releases: https://github.com/dapr/dapr/releases
+  dapr init -k --wait --timeout 600 # --runtime-version 1.8.0-xyz
 
   # Apply Dapr config
   kubectl apply -f $ROOT_DIRECTORY/deploy/runtime/k3d/.dapr/config.yaml

--- a/.vscode/scripts/runtime/local/ensure-dapr.sh
+++ b/.vscode/scripts/runtime/local/ensure-dapr.sh
@@ -38,7 +38,7 @@ fi
 
 echo ">> Initialize/reinitialize dapr runtime $DAPR_RUNTIME ..."
 dapr uninstall
-dapr init  --runtime-version $DAPR_RUNTIME
+dapr init --runtime-version $DAPR_RUNTIME
 
 echo "=========================="
 dapr --version

--- a/.vscode/scripts/runtime/local/ensure-dapr.sh
+++ b/.vscode/scripts/runtime/local/ensure-dapr.sh
@@ -20,36 +20,34 @@ echo "#######################################################"
 # Function to initialize Dapr
 init_dapr()
 {
-      echo ">> Initialize dapr runtime $DEFAULT_DAPR_RUNTIME ..."
+      echo "Initialize dapr runtime $DEFAULT_DAPR_RUNTIME_VERSION ..."
       dapr uninstall
-      dapr init --runtime-version $DEFAULT_DAPR_RUNTIME
+      dapr init --runtime-version $DEFAULT_DAPR_RUNTIME_VERSION
       echo "=========================="
       dapr --version
       echo "=========================="
 }
 
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../../../.." )
-DEFAULT_DAPR_VERSION=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.version | tr -d '"')
-DEFAULT_DAPR_RUNTIME=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.runtime | tr -d '"')
-INSTALLED_DAPR_VERSION=$(dapr --version | grep "CLI version: " | sed 's/^.*: //')
-INSTALLED_DAPR_RUNTIME=$(dapr --version | grep "Runtime version: " | sed 's/^.*: //')
+DEFAULT_DAPR_CLI_VERSION=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.cli.version | tr -d '"')
+DEFAULT_DAPR_RUNTIME_VERSION=$(cat $ROOT_DIRECTORY/prerequisite_settings.json | jq .dapr.runtime.version | tr -d '"')
+INSTALLED_DAPR_CLI_VERSION=$(dapr --version | grep "CLI version: " | sed 's/^.*: //' | sed 's/\s*//g')
+INSTALLED_DAPR_RUNTIME_VERSION=$(dapr --version | grep "Runtime version: " | sed 's/^.*: //' | sed 's/\s*//g')
 
-# If dapr is not installed, the runtime version will empty (i.e lenght = 0)
-# If the runtime version is not empty, the version will be either:
-# - Uninitialize: "n/a"
-# - Initialize: "x.y.z"
-if [ -z "$INSTALLED_DAPR_VERSION" ] || [ $INSTALLED_DAPR_VERSION != $DEFAULT_DAPR_VERSION ]; then
-      echo "Install dapr $DEFAULT_DAPR_VERSION"
-      wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s $DEFAULT_DAPR_VERSION
+# Check dapr CLI
+if [ "${INSTALLED_DAPR_CLI_VERSION}" != "${DEFAULT_DAPR_CLI_VERSION}" ]; then
+      echo "Install dapr CLI $DEFAULT_DAPR_CLI_VERSION"
+      wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s $DEFAULT_DAPR_CLI_VERSION
+else
+      echo "Dapr CLI $DEFAULT_DAPR_CLI_VERSION is already installed."
+fi
+
+# check dapr runtime
+if [ "${INSTALLED_DAPR_RUNTIME_VERSION}" != "${DEFAULT_DAPR_RUNTIME_VERSION}" ]; then
       init_dapr
 else
-      echo "Dapr is already installed, check for runtime and initialize if necessary."
-      if [ $INSTALLED_DAPR_RUNTIME != $DEFAULT_DAPR_RUNTIME ]; then
-            init_dapr
-      else
-            echo "Dapr already Initialized."
-            echo "=========================="
-            dapr --version
-            echo "=========================="
-      fi
+      echo "Dapr Runtime already Initialized."
+      echo "=========================="
+      dapr --version
+      echo "=========================="
 fi

--- a/.vscode/scripts/runtime/local/ensure-dapr.sh
+++ b/.vscode/scripts/runtime/local/ensure-dapr.sh
@@ -35,7 +35,7 @@ if ! [[ $version =~ ^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2}) ]]; then
 
       dapr uninstall
       # The --runtime-version is used to specify the dapr runtime version (i.e. remove the '#')
-      dapr init # --runtime-version 1.8.0-xyz
+      dapr init --runtime-version 1.8.0
 else
       echo "Dapr is already installed and initialized, skipping setup."
 fi

--- a/.vscode/scripts/runtime/local/ensure-dapr.sh
+++ b/.vscode/scripts/runtime/local/ensure-dapr.sh
@@ -34,7 +34,8 @@ if ! [[ $version =~ ^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2}) ]]; then
       fi
 
       dapr uninstall
-      dapr init --runtime-version 1.8.0-rc.3
+      # The --runtime-version is used to specify the dapr runtime version (i.e. remove the '#')
+      dapr init # --runtime-version 1.8.0-xyz
 else
       echo "Dapr is already installed and initialized, skipping setup."
 fi

--- a/prerequisite_settings.json
+++ b/prerequisite_settings.json
@@ -16,5 +16,9 @@
     },
     "databrokerimage": {
         "version": "v0.17.0"
+    },
+    "dapr":{
+        "version": "1.8.0",
+        "runtime": "1.8.1"
     }
 }

--- a/prerequisite_settings.json
+++ b/prerequisite_settings.json
@@ -17,8 +17,12 @@
     "databrokerimage": {
         "version": "v0.17.0"
     },
-    "dapr":{
-        "version": "1.8.0",
-        "runtime": "1.8.1"
+    "dapr": {
+        "cli": {
+            "version": "1.8.0"
+        },
+        "runtime": {
+            "version": "1.8.1"
+        }
     }
 }


### PR DESCRIPTION
# Description

Pin the dap cli and runtime versions for the stable 1.8.0/1.8.1 release.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#10569

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
