### PR TITLE
Same linter settings for vs code and ci worfklow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,16 @@
 {
 	"name": "Python VehicleApp",
 	"dockerFile": "Dockerfile${localEnv:DEVCONTAINER_PROXY}",
-	"build": { "args": { "PROXY_PORT" :  "${localEnv:DEVCONTAINER_PROXY_PORT}", "PROXY_HOST" : "${localEnv:DEVCONTAINER_PROXY_HOST}" } },
-	"runArgs": ["--init", "--privileged"],
-
+	"build": {
+		"args": {
+			"PROXY_PORT": "${localEnv:DEVCONTAINER_PROXY_PORT}",
+			"PROXY_HOST": "${localEnv:DEVCONTAINER_PROXY_HOST}"
+		}
+	},
+	"runArgs": [
+		"--init",
+		"--privileged"
+	],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"python.pythonPath": "/usr/bin/python3",
@@ -16,12 +23,11 @@
 		"python.linting.flake8Enabled": true,
 		"python.disableInstallationCheck": true
 	},
-
 	"features": {
-        "docker-in-docker": {
-            "version": "latest",
-            "moby": true
-        },
+		"docker-in-docker": {
+			"version": "latest",
+			"moby": true
+		},
 		"common": {
 			"username": "automatic",
 			"uid": "automatic",
@@ -31,8 +37,7 @@
 			"upgradePackages": true,
 			"nonFreePackages": false
 		}
-    },
-
+	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
@@ -47,12 +52,12 @@
 		"ms-kubernetes-tools.vscode-kubernetes-tools",
 		"matangover.mypy",
 		"anweber.vscode-httpyac",
-		"augustocdias.tasks-shell-input"
+		"augustocdias.tasks-shell-input",
+		"elagil.pre-commit-helper",
+		"ms-python.isort"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Ensure Dapr is running on opening the container
 	"onCreateCommand": "bash .devcontainer/scripts/postCreateCommand.sh",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.github/actions/pre-commit-action/action.yml
+++ b/.github/actions/pre-commit-action/action.yml
@@ -1,0 +1,34 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: pre-commit
+description: run pre-commit
+inputs:
+  extra_args:
+    description: Options to pass to pre-commit run
+    required: false
+    default: "--all-files"
+runs:
+  using: composite
+  steps:
+    - run: python -m pip install pre-commit
+      shell: bash
+    - run: python -m pip freeze --local
+      shell: bash
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Clone Release Documentation Action repository
-        uses: actions/checkout@v3
-        with:
-          repository: eclipse-velocitas/release-documentation-action
-          path: "./.github/actions"
-
       - uses: fusion-engineering/setup-git-credentials@v2
         with:
           credentials: https://user:${{ secrets.GITHUB_TOKEN }}@github.com/
@@ -55,7 +49,13 @@ jobs:
           pip install -r app/tests/requirements.txt
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: ./.github/actions/pre-commit-action
+
+      - name: Clone Release Documentation Action repository
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse-velocitas/release-documentation-action
+          path: "./.github/actions"
 
       - name: unit test
         shell: bash
@@ -115,6 +115,9 @@ jobs:
         with:
           percentage: "20"
           filename: "results/CodeCoverage/clover.xml"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
   initialize-matrix:
     runs-on: ubuntu-latest
@@ -184,6 +187,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Install required packages
         shell: pwsh
         run: |
@@ -235,6 +241,12 @@ jobs:
         if: always()
         with:
           files: ./results/IntTest/junit.xml
+
+      - name: Clone Release Documentation Action repository
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse-velocitas/release-documentation-action
+          path: "./.github/actions"
 
       - name: Package integration test result files
         uses: ./.github/actions/package

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,10 @@
 {
-    "python.linting.mypyEnabled" : false,
+    "python.linting.mypyEnabled": true,
     "python.linting.banditArgs": [
         "-c setup.cfg"
-      ],
+    ],
     "python.linting.pylintEnabled": true,
     "python.linting.flake8Enabled": true,
-    "python.linting.flake8Args": ["--ignore=E121,E402,F481,E501,F841"],
     "python.linting.enabled": true,
     "python.analysis.extraPaths": [
         "./proto",
@@ -32,5 +31,12 @@
     ],
     "python.defaultInterpreterPath": "/usr/bin/python3",
     "python.disableInstallationCheck": true,
-    "mypy.runUsingActiveInterpreter": true
+    "mypy.runUsingActiveInterpreter": true,
+    "pre-commit-helper.runOnSave": "all hooks",
+    "python.linting.mypyArgs": [],
+    "mypy.targets": [
+        "src"
+    ],
+    "python.linting.banditEnabled": true,
+    "python.linting.pydocstyleEnabled": true
 }

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -92,5 +92,4 @@
 |johanvanhelden/gha-clover-test-coverage-check|v1|MIT License|
 |peaceiris/actions-gh-pages|v3|MIT License|
 |peaceiris/actions-hugo|v2|MIT License|
-|pre-commit/action|v3.0.0|MIT License|
 |softprops/action-gh-release|v1|MIT License|

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [flake8]
-ignore = E203, E266, E501, W503, E402, B903
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9,B950
@@ -19,10 +18,6 @@ files =
 
 [mypy-vehicle_model.proto.*]
 ignore_errors = True
-
-
-[pycodestyle]
-ignore = E402
 
 [pydocstyle]
 match = '(?!test_).*\.py'


### PR DESCRIPTION
# Description

Making linter configuration the same for VSCode and CI workflow.

### Current setup:
In CI workflow [public pre commit action](https://github.com/pre-commit/action) is used, and the settings are different because of different `.pre-commi-config.yaml` files what is leading to different behavior in VS Code and CI Workflow.

### Approach implemented in this PR:
Using the same `.pre-commit-config.yaml` for all executions (no matter is it executing in VS Code or CI Workflow).
It is implemented creating the custom pre-commit action which uses `.pre-commit-config.yaml` from the root of the repo, and the same file is used by VS Code extenstion for pre-commit which will execute pre-commit on save and developer will be immediately notified about issues. And on the end, this pre-commit is preventing commits if checks are not successfull.   

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->
[AB#10473](https://softwaredefinedvehicle.visualstudio.com/SoftwareDefinedVehicle/_workitems/edit/10473)

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
