### PR TITLE
apply values from AppManifest.json to the deployment scripts

### DIFF
--- a/.github/workflows/build-docker-image-singlearch.yml
+++ b/.github/workflows/build-docker-image-singlearch.yml
@@ -90,8 +90,7 @@ jobs:
         push: false
         outputs: |
           type=oci,dest=./${{ matrix.component.Name }}.tar
-        context: ${{ matrix.component.ContextFolder }}
-        file: ${{ matrix.component.DockerFolder }}/Dockerfile
+        file: ${{ matrix.component.Dockerfile }}
         platforms: linux/${{ inputs.platform }}
         secrets: |
           "github_token=user:${{ secrets.GITHUB_TOKEN }}"

--- a/.vscode/scripts/runtime/k3d/build_vehicleapp.sh
+++ b/.vscode/scripts/runtime/k3d/build_vehicleapp.sh
@@ -13,27 +13,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../../../.." )
+APP_NAME=$(cat $ROOT_DIRECTORY/AppManifest.json | jq .[].Name | tr -d '"')
+DOCKERFILE_FILE="$(cat $ROOT_DIRECTORY/AppManifest.json | jq .[].Dockerfile | tr -d '"')"
 
 if [ -n "$HTTP_PROXY" ]; then
     echo "Building image with proxy configuration"
 
     cd $ROOT_DIRECTORY
     DOCKER_BUILDKIT=1 docker build \
-    -f src/VehicleApp/Dockerfile \
+    -f $DOCKERFILE_FILE \
     --progress=plain \
-    -t localhost:12345/vehicleapp:local \
+    -t localhost:12345/$APP_NAME:local \
     --build-arg HTTP_PROXY="$HTTP_PROXY" \
     --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
     --build-arg FTP_PROXY="$FTP_PROXY" \
     --build-arg ALL_PROXY="$ALL_PROXY" \
     --build-arg NO_PROXY="$NO_PROXY" . --no-cache
-    docker push localhost:12345/vehicleapp:local
+    docker push localhost:12345/$APP_NAME:local
 
 else
     echo "Building image without proxy configuration"
     # Build, push vehicleapi image - NO PROXY
 
     cd $ROOT_DIRECTORY
-    DOCKER_BUILDKIT=1 docker build -f src/VehicleApp/Dockerfile --progress=plain -t localhost:12345/vehicleapp:local . --no-cache
-    docker push localhost:12345/vehicleapp:local
+    DOCKER_BUILDKIT=1 docker build -f $DOCKERFILE_FILE --progress=plain -t localhost:12345/$APP_NAME:local . --no-cache
+    docker push localhost:12345/$APP_NAME:local
 fi

--- a/.vscode/scripts/runtime/k3d/deploy_vehicleapp.sh
+++ b/.vscode/scripts/runtime/k3d/deploy_vehicleapp.sh
@@ -13,8 +13,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../../../.." )
+APP_NAME=$(cat $ROOT_DIRECTORY/AppManifest.json | jq .[].Name | tr -d '"')
+APP_PORT=$(cat $ROOT_DIRECTORY/AppManifest.json | jq .[].Port | tr -d '"')
+APP_REGISTRY="k3d-registry.localhost:12345"
 
 helm uninstall vapp-chart --wait
 
 # Deploy in K3D
-helm install vapp-chart $ROOT_DIRECTORY/deploy/VehicleApp/helm --values $ROOT_DIRECTORY/deploy/VehicleApp/helm/values.yaml --wait --timeout 60s --debug
+REGISTRY="k3d-registry.localhost:12345/$APP_NAME"
+helm install vapp-chart $ROOT_DIRECTORY/deploy/VehicleApp/helm \
+    --values $ROOT_DIRECTORY/deploy/VehicleApp/helm/values.yaml \
+    --set imageVehicleApp.repository="$APP_REGISTRY/$APP_NAME" \
+    --set imageVehicleApp.name=$APP_NAME \
+    --set imageVehicleApp.daprAppid=$APP_NAME \
+    --set imageVehicleApp.daprPort=$APP_PORT \
+    --wait --timeout 60s --debug

--- a/AppManifest.json
+++ b/AppManifest.json
@@ -1,10 +1,7 @@
 [
     {
-        "Name": "vehicleapp",
-        "ContextFolder": ".",
-        "StartProgram": "main.py",
+        "Name": "seatadjuster",
         "Port": 50008,
-        "IsPublisher": 1,
-        "DockerFolder": "./src/VehicleApp"
+        "Dockerfile": "./src/VehicleApp/Dockerfile"
     }
 ]

--- a/src/VehicleApp/Dockerfile
+++ b/src/VehicleApp/Dockerfile
@@ -30,13 +30,12 @@ RUN /bin/bash -c 'set -ex && \
         pip3 install --no-cache-dir scons; \
     fi'
 
-
+RUN apt-get install -y git
 RUN pip3 install --no-cache-dir pyinstaller \
     && pip3 install --no-cache-dir patchelf \
     && pip3 install --no-cache-dir staticx \
     && pip3 install --no-cache-dir -r src/requirements.txt \
-    && pip3 install --no-cache-dir https://api.github.com/repos/eclipse-velocitas/vehicle-app-python-sdk/tarball/v0.2.0 \
-    && pip3 install --no-cache-dir https://api.github.com/repos/eclipse-velocitas/vehicle-model-python/tarball
+    && pip3 install --no-cache-dir -r src/requirements-links.txt
 
 WORKDIR /src
 


### PR DESCRIPTION
# Description

- Replace all hardcoded vehicleapp identifiers by the vehicle app attribute from the AppManifest.json file.
- remove unused AppManifest objects
- overwrite default Helm values by the values from the AppManifest.json
- improve building docker image dependencies 

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#10800

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
