### PR TITLE
Feedercan log level change

### DIFF
--- a/.vscode/scripts/runtime/local/run-feedercan.sh
+++ b/.vscode/scripts/runtime/local/run-feedercan.sh
@@ -43,7 +43,7 @@ pip3 install -r requirements.txt
 
 export DAPR_GRPC_PORT=$DATABROKER_GRPC_PORT
 export VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker
-export LOG_LEVEL=info,databroker=info,dbcfeeder.broker_client=debug,dbcfeeder=debug
+export LOG_LEVEL=info,databroker=info,dbcfeeder.broker_client=info,dbcfeeder=info
 
 ### Override default files for feedercan
 CONFIG_DIR="$ROOT_DIRECTORY/deploy/runtime/k3d/volume"

--- a/deploy/runtime/k3d/helm/templates/feedercan.yaml
+++ b/deploy/runtime/k3d/helm/templates/feedercan.yaml
@@ -46,7 +46,7 @@ spec:
             - name: VEHICLEDATABROKER_DAPR_APP_ID
               value: {{.Values.imageVehicleDataBroker.daprAppid}}
             - name: LOG_LEVEL
-              value: "info,databroker=info,dbcfeeder.broker_client=debug,dbcfeeder=debug"
+              value: "info,databroker=info,dbcfeeder.broker_client=info,dbcfeeder=info"
             - name: USECASE
               value: "databroker"
             - name: CANDUMP_FILE


### PR DESCRIPTION
# Description

Change of log level for feedercan from debug to info.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

[AB#10826](https://softwaredefinedvehicle.visualstudio.com/SoftwareDefinedVehicle/_workitems/edit/10826)

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
