### PR TITLE
Downgrade Dapr CLI to version 1.7.1 due to Dapr CLI bug #1043 (https:…

### DIFF
--- a/prerequisite_settings.json
+++ b/prerequisite_settings.json
@@ -19,7 +19,7 @@
     },
     "dapr": {
         "cli": {
-            "version": "1.8.0"
+            "version": "1.7.1"
         },
         "runtime": {
             "version": "1.8.1"


### PR DESCRIPTION
…//github.com/dapr/cli/issues/1043)

# Description

Downgrading Dapr CLI to v1.7.1 because dapr init is not working in Dapr CLI v1.8.0: It cannot download Dapr runtime.

## Azure DevOps PBI/Task reference

See bug ticket: https://github.com/dapr/cli/issues/1043

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
