### PR TITLE
fix NO_PROXY setting

### DIFF
--- a/.devcontainer/scripts/configure-proxies.sh
+++ b/.devcontainer/scripts/configure-proxies.sh
@@ -17,6 +17,10 @@ echo "#######################################################"
 echo "### Configure-proxies                               ###"
 echo "#######################################################"
 
+# Setting this again, since it was overwritten by the local docker.config
+# this is needed for K3D to work properly
+NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,192.168.122.0/24,cattle-system.svc,.svc,.cluster.local"
+
 echo "Use proxies: $USE_PROXIES"
 echo "Username: $USERNAME"
 echo "Http-proxy: $HTTP_PROXY"


### PR DESCRIPTION
# Description
K3D is not working without proper proxy settings. This PR is providing a fix for the setup.

## Azure DevOps PBI/Task reference

AB#11105

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
