### PR TITLE
Improvement: Avoid git checkout upon container build

### DIFF
--- a/.github/workflows/build-docker-image-singlearch.yml
+++ b/.github/workflows/build-docker-image-singlearch.yml
@@ -91,6 +91,7 @@ jobs:
           outputs: |
             type=oci,dest=./${{ matrix.component.Name }}.tar
           file: ${{ matrix.component.Dockerfile }}
+          context: .
           platforms: linux/${{ inputs.platform }}
           secrets: |
             "github_token=user:${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Description

docker/build-push-action@v2 does a git checkout if no context parameter is given to the action (git context is the default context). The repo is already checkout out though. We can improve this by setting context to the workspace root "."

## Azure DevOps PBI/Task reference

- None

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->
* [x] Release workflow is passing
