### PR TITLE
[11076]: fix create multi-arch image and fix the release workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,6 +23,10 @@ on:
       deployment-matrix-str:
         required: true
         type: string
+      multiarch:
+        required: false
+        type: boolean
+        default: false
     outputs:
       imageid:
         value: ${{ jobs.build-image.outputs.imageid }}
@@ -42,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Clone Release Documentation Action repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/release-documentation-action
           path: "./.github/actions"
@@ -58,13 +62,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: github-repository-name-case-adjusted
         name: Prepare repository name in lower case for docker upload. This supports repository names in mixed case
@@ -82,6 +79,18 @@ jobs:
           git config --global user.email "github-automation@users.noreply.github.com"
           git config --global user.name "Github Automation"
 
+      - name: Check Platform String
+        id: check
+        run: |
+          if [ ${{ inputs.multiarch }} == true ]; then
+            echo "Build Multiarch"
+            echo "::set-output name=platform::linux/amd64, linux/arm64"
+          else
+            echo "Build ${{inputs.platform}}"
+            echo "::set-output name=platform::linux/${{ inputs.platform }}"
+          fi
+        shell: bash
+
       - name: "${{ matrix.component.Name }} -- Build image"
         id: image_build
         uses: docker/build-push-action@v2
@@ -92,9 +101,10 @@ jobs:
             type=oci,dest=./${{ matrix.component.Name }}.tar
           file: ${{ matrix.component.Dockerfile }}
           context: .
-          platforms: linux/${{ inputs.platform }}
+          platforms: ${{ steps.check.outputs.platform }}
           secrets: |
             "github_token=user:${{ secrets.GITHUB_TOKEN }}"
+          tags: ${{ github.sha }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}
 
@@ -149,7 +159,7 @@ jobs:
         if: ${{ steps.image_build.outcome == 'success' }}
         uses: actions/upload-artifact@v3.1.0
         env:
-          VAPP_IMAGE: ${{ matrix.component.Name }}_${{ github.sha }}-${{ inputs.platform }}.tar
+          VAPP_IMAGE: ${{ matrix.component.Name }}-${{ inputs.platform }}
         with:
           name: ${{ env.VAPP_IMAGE }}
           path: ./${{ matrix.component.Name }}.tar

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -79,15 +79,15 @@ jobs:
           git config --global user.email "github-automation@users.noreply.github.com"
           git config --global user.name "Github Automation"
 
-      - name: Check Platform String
-        id: check
+      - name: Set Platform(s) String
+        id: set_platforms
         run: |
           if [ ${{ inputs.multiarch }} == true ]; then
             echo "Build Multiarch"
-            echo "::set-output name=platform::linux/amd64, linux/arm64"
+            echo "::set-output name=platforms::linux/amd64, linux/arm64"
           else
             echo "Build ${{inputs.platform}}"
-            echo "::set-output name=platform::linux/${{ inputs.platform }}"
+            echo "::set-output name=platforms::linux/${{ inputs.platform }}"
           fi
         shell: bash
 
@@ -101,7 +101,7 @@ jobs:
             type=oci,dest=./${{ matrix.component.Name }}.tar
           file: ${{ matrix.component.Dockerfile }}
           context: .
-          platforms: ${{ steps.check.outputs.platform }}
+          platforms: ${{ steps.set_platforms.outputs.platforms }}
           secrets: |
             "github_token=user:${{ secrets.GITHUB_TOKEN }}"
           tags: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
           files: ./results/UnitTest/junit.xml
 
       #########################################################
-      # This step was disabled temprorly due the required write
-      # access rights of the PR's for the external contributors.
+      # This step was disabled temporarily due to the required 
+      # write access rights of the PRs for external contributors.
       #########################################################
       #- name: Add code coverage comment to pr
       #  uses: romeovs/lcov-reporter-action@v0.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           files: ./results/UnitTest/junit.xml
 
       #########################################################
-      # This step was disabled temporarily due to the required 
+      # This step was disabled temporarily due to the required
       # write access rights of the PRs for external contributors.
       #########################################################
       #- name: Add code coverage comment to pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Clone Release Documentation Action repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/release-documentation-action
           path: "./.github/actions"
@@ -71,6 +71,10 @@ jobs:
         with:
           files: ./results/UnitTest/junit.xml
 
+      #########################################################
+      # This step was disabled temprorly due the required write
+      # access rights of the PR's for the external contributors.
+      #########################################################
       #- name: Add code coverage comment to pr
       #  uses: romeovs/lcov-reporter-action@v0.3.1
       #  with:
@@ -120,7 +124,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get matrix data
         id: export-deployment-matrix
@@ -132,17 +136,25 @@ jobs:
           echo "::set-output name=deployment-matrix::$MATRIX"
 
   build-image-amd64:
-    uses: ./.github/workflows/build-docker-image-singlearch.yml
+    uses: ./.github/workflows/build-docker-image.yml
     needs: [initialize-matrix]
     with:
       platform: amd64
       deployment-matrix-str: ${{ needs.initialize-matrix.outputs.deployment-matrix }}
 
   build-image-aarch64:
-    uses: ./.github/workflows/build-docker-image-singlearch.yml
+    uses: ./.github/workflows/build-docker-image.yml
     needs: [initialize-matrix]
     with:
       platform: aarch64
+      deployment-matrix-str: ${{ needs.initialize-matrix.outputs.deployment-matrix }}
+
+  build-image-multiarch:
+    uses: ./.github/workflows/build-docker-image.yml
+    needs: [initialize-matrix]
+    with:
+      platform: multiarch
+      multiarch: true
       deployment-matrix-str: ${{ needs.initialize-matrix.outputs.deployment-matrix }}
 
   run-integration-tests:
@@ -153,10 +165,10 @@ jobs:
       matrix:
         component: ${{ fromJson(needs.initialize-matrix.outputs.deployment-matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Clone Release Documentation Action repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/release-documentation-action
           path: "./.github/actions"
@@ -200,7 +212,7 @@ jobs:
       - name: Download stored image from artifacts
         uses: actions/download-artifact@v3.0.0
         env:
-          VAPP_IMAGE: ${{ matrix.component.Name }}_${{ github.sha }}-amd64.tar
+          VAPP_IMAGE: ${{ matrix.component.Name }}-amd64
         with:
           name: ${{ env.VAPP_IMAGE }}
           path: ./.github/scripts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get matrix data
         id: export-deployment-matrix
@@ -37,6 +37,7 @@ jobs:
           MATRIX=$(cat ./AppManifest.json | tr '\n' ' ')
 
           echo "::set-output name=deployment-matrix::$MATRIX"
+
   upload-images:
     name: "Upload image (${{ matrix.component.Name }})"
     runs-on: ubuntu-latest
@@ -47,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: get_version
         uses: battila7/get-version-action@v2
@@ -62,21 +63,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: github-repository-name-case-adjusted
-        name: Prepare repository name in lower case for docker upload. This supports repository names in mixed case
+        name: Prepare repository name in lower case for docker upload.
         uses: ASzc/change-string-case-action@v1
         with:
           string: ${{ github.repository }}
 
+      - name: Download builds from CI workflow artifacts
+        uses: dawidd6/action-download-artifact@v2.23.0
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: ci.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          path: ${{github.workspace}}
+
       - name: "${{ matrix.component.Name }} -- Publish release image to GHCR"
+        working-directory: ${{github.workspace}}
         env:
+          VAPP_IMAGE: ${{ matrix.component.Name }}-multiarch/${{ matrix.component.Name }}.tar
           VAPP_NAME: ${{ matrix.component.Name }}
-          COMMIT: ${{ github.sha }}
           VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
-          GIT_HUB_REPOSITORY_NAME_LOWER_CASE: ${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}
-          TARGET_REGISTRY: 'ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}' # Please use your target container registry
+          REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
-          echo "Copy vApp image 'docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAPP_NAME:$COMMIT' to 'docker://$TARGET_REGISTRY/$VAPP_NAME:$VAPP_VERSION'"
-          skopeo copy --all  "docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAPP_NAME:$COMMIT" "docker://$TARGET_REGISTRY/$VAPP_NAME:$VAPP_VERSION"
+          echo "Copy vApp image $VAPP_IMAGE to 'docker://$REGISTRY/$VAPP_NAME:$VAPP_VERSION'"
+          skopeo copy --all  oci-archive:$VAPP_IMAGE "docker://$REGISTRY/$VAPP_NAME:$VAPP_VERSION"
 
   release-documentation:
     name: Generate release documentation
@@ -84,17 +94,17 @@ jobs:
     env:
       TEST_RESULT_FOLDER_NAME: test-results
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Clone Release Documentation Action repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/release-documentation-action
           path: "./.github/actions"
 
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: "14.x"
 
       - name: Conditional input event value
         uses: haya14busa/action-cond@v1
@@ -109,8 +119,8 @@ jobs:
         id: wait-for-CI
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "create-multiarch-image"
-          ref:  ${{ steps.condval.outputs.value }}
+          checkName: "build-image-multiarch"
+          ref: ${{ steps.condval.outputs.value }}
           timeoutSeconds: 600
 
       - name: Download artifact
@@ -118,7 +128,7 @@ jobs:
         with:
           workflow: ci.yml
           workflow_conclusion: success
-          commit:  ${{ steps.condval.outputs.value }}
+          commit: ${{ steps.condval.outputs.value }}
           path: .vehicleApp/Documentation/Inbox
 
       - name: Render documentation (test-results)
@@ -150,7 +160,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.89.4'
+          hugo-version: "0.89.4"
           extended: true
 
       - name: Set tags output


### PR DESCRIPTION
# Description

- create multi-arch OCI archive image
- fix release workflow to used the pre-built Image 
- update checkout action to the new v3

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#11076

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [x] Release workflow is passing
