### PR TITLE
[Bugfix] Fix broken links on docs in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ This is a template repository to kickstart the creation of a Python Vehicle App.
 This repository provides you with a complete development environment for your own Vehicle App based on the [Software defined vehicle platform](https://sdv.eclipse.org/) including a sample Vehicle App using the [Vehicle App Python SDK](https://github.com/eclipse-velocitas/vehicle-app-python-sdk). The development environment uses the [Development Container](https://code.visualstudio.com/docs/remote/create-dev-container#:~:text=%20Create%20a%20development%20container%20%201%20Path,additional%20software%20in%20your%20dev%20container.%20More%20) feature of Visual Studio Code.
 
 ## Documentation
-* [Velocitas Development Model](https://eclipse-velocitas.github.io/velocitas-docs/docs/concepts/development_model/)
-* [Vehicle App Python SDK Overview](https://eclipse-velocitas.github.io/velocitas-docs/docs/concepts/python_vehicle_app_sdk/)
+* [Velocitas Development Model](https://eclipse-velocitas.github.io/velocitas-docs/docs/about/development_model/)
+* [Vehicle App SDK Overview](https://eclipse-velocitas.github.io/velocitas-docs/docs/about/development_model/vehicle_app_sdk/)
 
 ## Quickstart Tutorials
 1. [Setup and Explore Development Enviroment](https://eclipse-velocitas.github.io/velocitas-docs/docs/tutorials/quickstart/)
-1. [Develop your own Vehicle Model in Python](https://eclipse-velocitas.github.io/velocitas-docs/docs/tutorials/tutorial_how_to_create_a_vehicle_model/)
-1. [Develop your own Vehicle App in Python](https://eclipse-velocitas.github.io/velocitas-docs/docs/tutorials/tutorial_how_to_create_a_vehicle_app/)
+1. [Develop your own Vehicle Model](https://eclipse-velocitas.github.io/velocitas-docs/docs/tutorials/tutorial_how_to_create_a_vehicle_model/)
+1. [Develop your own Vehicle App](https://eclipse-velocitas.github.io/velocitas-docs/docs/tutorials/vehicle-app-development/)
 
 ## Contribution
 - [GitHub Issues](https://github.com/eclipse-velocitas/vehicle-app-python-template/issues)
 - [Mailing List](https://accounts.eclipse.org/mailing-list/velocitas-dev)
-- [Contribution](https://eclipse-velocitas.github.io/velocitas-docs/docs/contribution/)
+- [Contribution](https://eclipse-velocitas.github.io/velocitas-docs/docs/contribution-guidelines)


### PR DESCRIPTION
# Proposal to fix links

<!--
Please explain the changes you've made.
-->

## Azure DevOps PBI/Task reference
Don't know any

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
