### PR TITLE
Fix mapping bug for canfeeder in k3d

### DIFF
--- a/deploy/runtime/k3d/helm/templates/configmap.yaml
+++ b/deploy/runtime/k3d/helm/templates/configmap.yaml
@@ -18,6 +18,6 @@ metadata:
   name: feeder-config
 data:
   dbcfile: "/mnt/data/dbcfile.dbc"
-  mappying: "/mnt/data/mappying.yml"
+  mapping: "/mnt/data/mapping.yml"
   candump: "/mnt/data/candump.log"
   usecase: "/mnt/data/databroker"

--- a/deploy/runtime/k3d/helm/values.yaml
+++ b/deploy/runtime/k3d/helm/values.yaml
@@ -53,7 +53,7 @@ imageFeederCan:
   daprLogLevel: debug
   candumpfile: "/data/candumpDefault.log"
   dbcfile: "/data/dbcfileDefault.dbc"
-  mappying: "/data/mappingDefault.yml"
+  mapping: "/data/mappingDefault.yml"
   tag: latest
 
 nameOverride: ""


### PR DESCRIPTION
Signed-off-by: Dennis Meister <dennis.meister@bosch.com>

# Description

Fixing bug for can feeder mapping file in local k3d environment

## Azure DevOps PBI/Task reference

[AB#_[11201]_](https://softwaredefinedvehicle.visualstudio.com/SoftwareDefinedVehicle/_workitems/edit/11201)

## Checklist

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
