### PR TITLE
PreCommit Hooks can be executed without errors

### DIFF
--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -44,4 +44,4 @@ pip3 install setuptools==59.6.0
 # Required because of pre-commit
 # dependency to python-Levenshtein
 # wheels are missing and have to built from scratch
-sudo apt-get update && sudo apt-get install -y build-essential
+sudo apt-get update && sudo apt-get install -y build-essential python3-dev

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -35,3 +35,13 @@ REQUIREMENTS="./app/tests/requirements.txt"
 if [ -f $REQUIREMENTS ]; then
     pip3 install -r $REQUIREMENTS
 fi
+
+# Required because of a bug in virtualenv
+# until PR is released
+# https://github.com/pypa/virtualenv/pull/2415
+pip3 install setuptools==59.6.0
+
+# Required because of pre-commit
+# dependency to python-Levenshtein
+# wheels are missing and have to built from scratch
+sudo apt-get update && sudo apt-get install -y build-essential


### PR DESCRIPTION
## Desription
pre-commit requires virtualenv, and with recent ubuntu versions 22.x there was a change that makes virtualenv copy the python executable into ./local/bin instead of ./bin
This breaks pre-commit.

## Changes
* downgrade of python setuptools package 
* install two additional packages via apt-get that were missing in base image to build pre-commit wheels

fixes #45 

## Notes
I created a follow up as improvement for the base image: https://github.com/eclipse-velocitas/devcontainer-base-images/issues/2

## Checklist
### VehicleApp
- [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
- [x] Vehicle App can process MQTT messages and call the seat service
- [ ] Vehicle App can be deployed to local K3D and is running (blocked by current proxy issue)
- [ ] n/a ~~Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.~~
- [ ] n/a ~~Extended the documentation in Velocitas repo~~
- [ ] n/a ~~Extended the documentation in README.md~~
### DevContainer
- [x] Devcontainer can be opened successfully
- [ ] Devcontainer can be opened successfully behind a corporate proxy
- [x] Devcontainer can be re-built successfully
### Release flow
- [ ] n/a ~~Release workflow is passing~~
