### PR TITLE
Remove non-existing pylint checker identifier

### DIFF
--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -35,13 +35,3 @@ REQUIREMENTS="./app/tests/requirements.txt"
 if [ -f $REQUIREMENTS ]; then
     pip3 install -r $REQUIREMENTS
 fi
-
-# Required because of a bug in virtualenv
-# until PR is released
-# https://github.com/pypa/virtualenv/pull/2415
-pip3 install setuptools==59.6.0
-
-# Required because of pre-commit
-# dependency to python-Levenshtein
-# wheels are missing and have to built from scratch
-sudo apt-get update && sudo apt-get install -y build-essential python3-dev

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -35,3 +35,13 @@ REQUIREMENTS="./app/tests/requirements.txt"
 if [ -f $REQUIREMENTS ]; then
     pip3 install -r $REQUIREMENTS
 fi
+
+# Required because of a bug in virtualenv
+# until PR is released
+# https://github.com/pypa/virtualenv/pull/2415
+pip3 install setuptools==59.6.0
+
+# Required because of pre-commit
+# dependency to python-Levenshtein
+# wheels are missing and have to built from scratch
+sudo apt-get update && sudo apt-get install -y build-essential python3-dev

--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,6 @@ disable=raw-checker-failed,
         C0114,
         C0116,
         W0703,
-        R0201,
         R0903,
         W0212
 


### PR DESCRIPTION
The R0201 identifier does not exist and causes pylint to complain on every invocation.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch.io>