### PR TITLE
setting zsh as default shell in devcontainer.json/settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,13 @@
 		"python.formatting.provider": "black",
 		"python.linting.banditEnabled": true,
 		"python.linting.flake8Enabled": true,
-		"python.disableInstallationCheck": true
+		"python.disableInstallationCheck": true,
+		"terminal.integrated.defaultProfile.linux": "zsh", 
+		"terminal.integrated.profiles.linux": {
+			"zsh": {
+				"path": "/bin/zsh"
+			}
+		}
 	},
 	// workaround for the devcontainer features
 	"overrideCommand": false,


### PR DESCRIPTION
# Description
This PR sets the `zsh` as default shell for the terminal by adding the explicit default configuration to the devcontainer.json file in the `settings`-section

fixes #55 
## Checklist
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be re-built successfully