### PR TITLE
Set zsh as default shell

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,13 @@
 		"python.formatting.provider": "black",
 		"python.linting.banditEnabled": true,
 		"python.linting.flake8Enabled": true,
-		"python.disableInstallationCheck": true
+		"python.disableInstallationCheck": true,
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+            "zsh": {
+                "path": "/usr/bin/zsh"
+            }
+        }
 	},
 	// workaround for the devcontainer features
 	"overrideCommand": false,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,19 +18,18 @@
 		"python.linting.banditEnabled": true,
 		"python.linting.flake8Enabled": true,
 		"python.disableInstallationCheck": true,
-        "terminal.integrated.defaultProfile.linux": "zsh",
-        "terminal.integrated.profiles.linux": {
-            "zsh": {
-                "path": "/usr/bin/zsh"
-            }
-        }
+		"terminal.integrated.defaultProfile.linux": "zsh",
+		"terminal.integrated.profiles.linux": {
+			"zsh": {
+				"path": "/usr/bin/zsh"
+			}
+		}
 	},
 	// workaround for the devcontainer features
 	"overrideCommand": false,
 	"mounts": [
 		"source=dind-var-lib-docker,target=/var/lib/docker,type=volume"
 	],
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
@@ -49,7 +48,6 @@
 		"elagil.pre-commit-helper",
 		"ms-python.isort"
 	],
-
 	"onCreateCommand": "bash .devcontainer/scripts/postCreateCommand.sh",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"


### PR DESCRIPTION
# Description

Changes the devContainers default profile/shell to zsh

## Azure DevOps PBI/Task reference


## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
