### PR TITLE
Adapt to new return type for DataPoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -38,12 +38,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         exclude: >
@@ -67,14 +67,14 @@ repos:
         types_or: [python]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.1
+    rev: 1.7.4
     hooks:
       - id: bandit
         args: ["--skip=B101"]
         types_or: [python]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.920"
+    rev: "v0.982"
     hooks:
       - id: mypy
         args: [app]
@@ -87,12 +87,12 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.0.9
+    rev: v0.1.17
     hooks:
       - id: helmlint
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.3.1
     hooks:
       - id: insert-license
         files: '.*\.(py|pyi|yaml|yml|sh|helmignore|dockerignore|gitignore)$'

--- a/.pylintrc
+++ b/.pylintrc
@@ -388,7 +388,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=google.protobuf.timestamp_pb2
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/app/requirements-links.txt
+++ b/app/requirements-links.txt
@@ -1,2 +1,2 @@
-git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@0.7.0
+git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@v0.7.0
 git+https://github.com/eclipse-velocitas/vehicle-model-python.git@v0.3.0

--- a/app/requirements-links.txt
+++ b/app/requirements-links.txt
@@ -1,2 +1,2 @@
-git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@v0.6.0
+git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@0.7.0
 git+https://github.com/eclipse-velocitas/vehicle-model-python.git@v0.3.0

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -73,7 +73,7 @@ class SampleApp(VehicleApp):
         # Get the current vehicle speed value from the received DatapointReply.
         # The DatapointReply containes the values of all subscribed DataPoints of
         # the same callback.
-        vehicle_speed = data.get(self.Vehicle.OBD.Speed)
+        vehicle_speed = data.get(self.Vehicle.OBD.Speed).value
 
         # Do anything with the received value.
         # Example:
@@ -97,7 +97,7 @@ class SampleApp(VehicleApp):
         )
 
         # Getting current speed from VehicleDataBroker using the DataPoint getter.
-        vehicle_speed = await self.Vehicle.OBD.Speed.get()
+        vehicle_speed = (await self.Vehicle.OBD.Speed.get()).value
 
         # Do anything with the speed value.
         # Example:

--- a/app/tests/unit/test_run.py
+++ b/app/tests/unit/test_run.py
@@ -18,6 +18,8 @@
 from unittest import mock
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sdv.vdb.types import TypedDataPointResult
 from sdv.vehicle_app import VehicleApp
 from sdv_model import vehicle  # type: ignore
 
@@ -26,15 +28,16 @@ MOCKED_SPEED = 0.0
 
 @pytest.mark.asyncio
 async def test_for_get_speed():
+    result = TypedDataPointResult("foo", MOCKED_SPEED, Timestamp(seconds=10, nanos=0))
     # Disable no-value-for-parameter, seems to be false positive with mock lib
     # pylint: disable=no-value-for-parameter
     with mock.patch.object(
         vehicle.OBD.Speed,
         "get",
         new_callable=mock.AsyncMock,
-        return_value=MOCKED_SPEED,
+        return_value=result,
     ):
-        current_speed = await vehicle.OBD.Speed.get()
+        current_speed = (await vehicle.OBD.Speed.get()).value
         assert current_speed == MOCKED_SPEED
 
 


### PR DESCRIPTION
# Description

Adapt the template to the use of the new `TypedDataPointResult` of the updated SDK

## Azure DevOps PBI/Task reference


## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
