### PR TITLE
Comment out test asserts for template application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,13 +218,13 @@ jobs:
           pip install -r app/tests/requirements.txt
           pytest ./app/tests/integration --override-ini junit_family=xunit1 --junit-xml=./results/IntTest/junit.xml
 
-      - name: Publish Unit Test Results
+      - name: Publish integration test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: ./results/IntTest/junit.xml
 
-      - name: Clone Release Documentation Action repository
+      - name: Clone release documentation action repository
         uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/release-documentation-action

--- a/app/tests/integration/integration_test.py
+++ b/app/tests/integration/integration_test.py
@@ -44,5 +44,10 @@ async def test_get_current_speed():
     # add expected message to get it assert
     expected_message = "Current Speed = 0.0"
 
-    assert body["result"]["status"] == 0
-    assert body["result"]["message"] == expected_message
+    print(f"Received response: {body}")
+    print(f"Expected message: {expected_message}")
+
+    # Uncomment to test the behaviour of the SampleApp as provided by
+    #     the template repository:
+    # assert body["result"]["status"] == 0
+    # assert body["result"]["message"] == expected_message

--- a/app/tests/unit/test_run.py
+++ b/app/tests/unit/test_run.py
@@ -38,7 +38,10 @@ async def test_for_get_speed():
         return_value=result,
     ):
         current_speed = (await vehicle.OBD.Speed.get()).value
-        assert current_speed == MOCKED_SPEED
+        print(f"Received speed: {current_speed}")
+        # Uncomment to test the behaviour of the SampleApp as provided by
+        #     the template repository:
+        # assert current_speed == MOCKED_SPEED
 
 
 @pytest.mark.asyncio
@@ -52,7 +55,11 @@ async def test_for_publish_to_topic():
         response = await VehicleApp.publish_mqtt_event(
             str("sampleTopic"), get_sample_response_data()  # type: ignore
         )
-        assert response == -1
+
+        print(f"Received response: {response}")
+        # Uncomment to test the behaviour of the SampleApp as provided by
+        #     the template repository:
+        # assert response == -1
 
 
 def get_sample_response_data():


### PR DESCRIPTION
# Description

Comment out the non-generic unit and integration tests to easily allow users to start with own code after cloning the template repo and not bothered with failing tests of example code. 

## Azure DevOps PBI/Task reference

AB#_11187_

## Checklist

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
