### PR TITLE
fix step output to enable multi-arch build again

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -84,10 +84,10 @@ jobs:
         run: |
           if [ ${{ inputs.multiarch }} == true ]; then
             echo "Build Multiarch"
-            echo "name=platforms::linux/amd64, linux/arm64" >> $GITHUB_OUTPUT
+            echo "platforms=linux/amd64, linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "Build ${{inputs.platform}}"
-            echo "name=platforms::linux/${{ inputs.platform }}" >> $GITHUB_OUTPUT
+            echo "platforms=linux/${{ inputs.platform }}" >> $GITHUB_OUTPUT
           fi
         shell: bash
 


### PR DESCRIPTION
# Description
The multi-arch wasn't really building multiple architectures because the output from the step was not fitting the input from the next step.
This fixes the problem.