### PR TITLE
Fix for k3d logs

### DIFF
--- a/.devcontainer/scripts/configure-proxies.sh
+++ b/.devcontainer/scripts/configure-proxies.sh
@@ -22,7 +22,7 @@ if [ "$HTTP_PROXY" != "" ]; then
     CONFIGURE_GIT="true"
     FTP_PROXY=$HTTP_PROXY
     ALL_PROXY=$HTTP_PROXY
-    NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,192.168.122.0/24,cattle-system.svc,.svc,.cluster.local"
+    NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,192.168.122.0/24,172.0.0.0/8,cattle-system.svc,.svc,.cluster.local"
 fi
 
 echo "Use proxies: $USE_PROXIES"

--- a/.vscode/scripts/runtime/k3d/configure_controlplane.sh
+++ b/.vscode/scripts/runtime/k3d/configure_controlplane.sh
@@ -33,10 +33,10 @@ then
       -p "31883:31883" \
       -p "30555:30555" \
       -p "30051:30051" \
+      --volume $ROOT_DIRECTORY/deploy/runtime/k3d/volume:/mnt/data@server:0 \
       -e "HTTP_PROXY=$HTTP_PROXY@server:0" \
       -e "HTTPS_PROXY=$HTTPS_PROXY@server:0" \
-      --volume $ROOT_DIRECTORY/deploy/runtime/k3d/volume:/mnt/data@server:0 \
-      -e "NO_PROXY=localhost@server:0"
+      -e "NO_PROXY=$NO_PROXY@server:0"   
   else
     echo "Creating cluster without proxy configuration"
     k3d cluster create cluster \

--- a/.vscode/scripts/runtime/k3d/deploy_runtime.sh
+++ b/.vscode/scripts/runtime/k3d/deploy_runtime.sh
@@ -48,7 +48,15 @@ then
     done
 
     # We set the tag to the version from the variables above in the script. This overwrites the default values in the values-file.
-    helm install vehicleappruntime $ROOT_DIRECTORY/deploy/runtime/k3d/helm --values $ROOT_DIRECTORY/deploy/runtime/k3d/helm/values.yaml --set imageSeatService.tag=$SEATSERVICE_TAG --set imageVehicleDataBroker.tag=$DATABROKER_TAG --set imageFeederCan.tag=$FEEDERCAN_TAG --wait --timeout 60s --debug
+    helm install vehicleappruntime \
+        $ROOT_DIRECTORY/deploy/runtime/k3d/helm \
+        --values $ROOT_DIRECTORY/deploy/runtime/k3d/helm/values.yaml \
+        --set imageSeatService.tag=$SEATSERVICE_TAG \
+        --set imageVehicleDataBroker.tag=$DATABROKER_TAG \
+        --set imageFeederCan.tag=$FEEDERCAN_TAG \
+        --wait \
+        --timeout 60s \
+        --debug
 
 else
     echo "Runtime already deployed. To redeploy the components, run the task 'K3D - Uninstall runtime' first."


### PR DESCRIPTION
# Description

ADO-11205 Fix for k3d logs issue.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
