### PR TITLE
Change vehicle member variable for consistency in digital auto and cpp

### DIFF
--- a/app/src/main.py
+++ b/app/src/main.py
@@ -56,14 +56,14 @@ class SampleApp(VehicleApp):
     def __init__(self, vehicle_client: Vehicle):
         # SampleApp inherits from VehicleApp.
         super().__init__()
-        self.vehicle = vehicle_client
+        self.Vehicle = vehicle_client
 
     async def on_start(self):
         """Run when the vehicle app starts"""
         # This method will be called by the SDK when the connection to the
         # Vehicle DataBroker is ready.
         # Here you can subscribe for the Vehicle Signals update (e.g. Vehicle Speed).
-        await self.vehicle.Speed.subscribe(self.on_speed_change)
+        await self.Vehicle.Speed.subscribe(self.on_speed_change)
 
     async def on_speed_change(self, data: DataPointReply):
         """The on_speed_change callback, this will be executed when receiving a new
@@ -71,7 +71,7 @@ class SampleApp(VehicleApp):
         # Get the current vehicle speed value from the received DatapointReply.
         # The DatapointReply containes the values of all subscribed DataPoints of
         # the same callback.
-        vehicle_speed = data.get(self.vehicle.Speed).value
+        vehicle_speed = data.get(self.Vehicle.Speed).value
 
         # Do anything with the received value.
         # Example:
@@ -95,7 +95,7 @@ class SampleApp(VehicleApp):
         )
 
         # Getting current speed from VehicleDataBroker using the DataPoint getter.
-        vehicle_speed = (await self.vehicle.Speed.get()).value
+        vehicle_speed = (await self.Vehicle.Speed.get()).value
 
         # Do anything with the speed value.
         # Example:


### PR DESCRIPTION
Signed-off-by: Dennis Meister <dennis.meister@bosch.com>

# Description

Just change back member variable of vehicle back to before because of consistency reasons in digital auto + cpp

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
