### PR TITLE
Bugfix: AppManifest as part of release assets

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -169,6 +169,6 @@ jobs:
         if: ${{ steps.image_build.outcome == 'success' }}
         uses: actions/upload-artifact@v3
         with:
-          name: "AppManifest.json"
+          name: AppManifest
           path: ./app/AppManifest.json
           if-no-files-found: error

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/license-check
-          ref: v1.2.0
+          ref: v1.2.1
           path: .github/actions/license-check
 
       - name: Run License Checker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
           path: ./ci-artifacts
-      
+
       - name: ${{ matrix.component.Name }} -- Upload assets
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,13 @@ jobs:
         with:
           workflow: ci.yml
           workflow_conclusion: success
+          path: ./ci-artifacts
 
-      - name: ${{ matrix.component.Name }} -- Upload AppManifest.json to artifacts"
-        uses: actions/upload-artifact@v3
+      - name: ${{ matrix.component.Name }} -- Upload assets
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: "AppManifest.json"
-          path: ./AppManifest.json
-          if-no-files-found: error
+          files: ./ci-artifacts/AppManifest/AppManifest.json
 
   release-documentation:
     name: Generate release documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
           path: ./ci-artifacts
-
+      
       - name: ${{ matrix.component.Name }} -- Upload assets
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -10,7 +10,7 @@
         },
         {
             "name": "devenv-github-workflows",
-            "version": "v1.0.5"
+            "version": "v1.0.6"
         },
         {
             "name": "devenv-github-templates",

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -10,7 +10,7 @@
         },
         {
             "name": "devenv-github-workflows",
-            "version": "v1.0.4"
+            "version": "v1.0.5"
         },
         {
             "name": "devenv-github-templates",


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

This PR implements upload of AppManifest provided from CI workflow to Release assets.

Link to successful release workflow run: https://github.com/eclipse-velocitas/vehicle-app-python-template/actions/runs/4044489992

<!--
Please explain the changes you've made.
-->

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

[AB#12587](https://softwaredefinedvehicle.visualstudio.com/SoftwareDefinedVehicle/_workitems/edit/12587)

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [x] Release workflow is passing
