### PR TITLE
Revert "Enhacement: Event loop init short form (#85)"

### DIFF
--- a/app/src/main.py
+++ b/app/src/main.py
@@ -17,6 +17,7 @@
 import asyncio
 import json
 import logging
+import signal
 
 from sdv.util.log import (  # type: ignore
     get_opentelemetry_log_factory,
@@ -121,4 +122,7 @@ async def main():
     await vehicle_app.run()
 
 
-asyncio.run(main())
+LOOP = asyncio.get_event_loop()
+LOOP.add_signal_handler(signal.SIGTERM, LOOP.stop)
+LOOP.run_until_complete(main())
+LOOP.close()


### PR DESCRIPTION
This reverts commit 7e81f793c26c40aad5fa1f553628dbe2821c2fa8.

<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

This commit reverts a change that leads to mqtt events not being received properly.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
