### PR TITLE
Fix: Revert mount to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,6 +32,7 @@
 	},
 	// workaround for the devcontainer features
 	"overrideCommand": false,
+	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -18,7 +18,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v1.0.2"
+            "version": "v1.0.3"
         }
     ],
     "variables": {


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description
This PR fixes issue with K3d, mount to devcontainer was missing.
<!--
Please explain the changes you've made.
-->

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
