### PR TITLE
Pin pyinstaller version to fix staticx build

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -32,7 +32,7 @@ RUN /bin/bash -c 'set -ex && \
     fi'
 
 RUN apt-get install -y git
-RUN pip3 install --no-cache-dir pyinstaller \
+RUN pip3 install --no-cache-dir pyinstaller==5.9.0 \
     && pip3 install --no-cache-dir patchelf==0.17.0.0 \
     && pip3 install --no-cache-dir staticx \
     && pip3 install --no-cache-dir -r ./app/requirements.txt \


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

Pyinstaller recently got a version bump to 5.10.0 which seems to be incompatible with staticx's pyinstaller hook. Hence we need to pin the version to fix the containerization / staticx build.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

None

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
