### PR TITLE
Take release artifacts from multiarch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           checkName: build-image-multiarch / Building image (${{ matrix.component.name }})
           token: ${{ secrets.GITHUB_TOKEN }}
-          timeoutSeconds: 1200
+          timeoutSeconds: 1800
           intervalSeconds: 20
 
       - name: Download builds from Build multiarch image workflow artifacts
@@ -96,21 +96,19 @@ jobs:
           echo "Copy vApp image $VAPP_IMAGE to '$tag'"
           skopeo copy --all  oci-archive:$VAPP_IMAGE "$tag"
 
-      - name: ${{ matrix.component.name }} -- Download CI artifacts
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: ci.yml
-          workflow_conclusion: success
-          path: ./ci-artifacts
+      - name: zip HelmChart
+        run: |
+          cd ${{github.workspace}}/HelmChart
+          zip -r ${{github.workspace}}/HelmChart.zip .
 
       - name: ${{ matrix.component.name }} -- Upload assets
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ./ci-artifacts/AppManifest/AppManifest.json
-            ./ci-artifacts/Podspec/Podspec.yaml
-            ./ci-artifacts/HelmChart
+            ${{github.workspace}}/AppManifest/AppManifest.json
+            ${{github.workspace}}/Podspec/podspec.yaml
+            ${{github.workspace}}/HelmChart.zip
 
   release-documentation:
     name: Generate release documentation

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -6,7 +6,7 @@
         },
         {
             "name": "devenv-github-workflows",
-            "version": "v2.0.3"
+            "version": "v2.0.4"
         },
         {
             "name": "devenv-github-templates",


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

Take the release artefacts from the build-multiarch-image workflow (instead of CI).
This makes it working with C++ workflows, where those artefacts aren't created during CI workflow.

## Issue ticket number and link

AB#14620

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
