### PR TITLE
feature: add support for grpc-interface-support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.1
+FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.2
 
 # Force dapr to use localhost traffic
 ENV DAPR_HOST_IP="127.0.0.1"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,9 +18,8 @@
 				"python.defaultInterpreterPath": "/usr/bin/python3",
 				"python.analysis.typeCheckingMode": "basic",
 				// Strong Type Checker
-				"python.linting.mypyEnabled": true,
+				"mypy.enabled": true,
 				"mypy.runUsingActiveInterpreter": true,
-				"python.linting.mypyArgs": [],
 				"mypy.targets": [
 					"app"
 				],
@@ -29,9 +28,6 @@
 				"python.linting.banditArgs": [
 					"-c setup.cfg"
 				],
-				// Only Flake8 is used as linter and static code analyzer, as faster tool
-				"python.linting.enabled": true,
-				"python.linting.flake8Enabled": true,
 				// Style Checker for Python Docs
 				"python.linting.pydocstyleEnabled": true,
 				"python.analysis.extraPaths": [
@@ -40,10 +36,12 @@
 				],
 				"python.testing.unittestEnabled": false,
 				"python.testing.pytestEnabled": true,
-				// Style Formatter
-				"python.formatting.provider": "black",
+				"[python]": {
+					// Style Formatter
+					"editor.defaultFormatter": "ms-python.black-formatter"
+				},
 				"vs-kubernetes": {
-					"vscode-kubernetes.kubectl-path.linux": "/usr/bin/kubectl",
+					"vscode-kubernetes.kubectl-path.linux": "/usr/local/bin/kubectl",
 					"vscode-kubernetes.helm-path.linux": "/usr/local/bin/helm"
 				},
 				"terminal.integrated.defaultProfile.linux": "zsh",
@@ -86,7 +84,9 @@
 				"matangover.mypy",
 				"augustocdias.tasks-shell-input",
 				"ms-python.isort",
-				"ms-python.flake8"
+				"ms-python.flake8",
+				"ms-python.black-formatter",
+				"ms-python.mypy-type-checker"
 			]
 		}
 	},

--- a/.github/scripts/deploy_image_from_artifact.sh
+++ b/.github/scripts/deploy_image_from_artifact.sh
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+set -e
+
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../.." )
 APP_ARTIFACT_NAME=$(cat $ROOT_DIRECTORY/app/AppManifest.json | jq -r .name | tr -d '"')
 APP_NAME_LOWERCASE=$(echo $APP_ARTIFACT_NAME | tr '[:upper:]' '[:lower:]')

--- a/.github/scripts/deploy_image_from_artifact.sh
+++ b/.github/scripts/deploy_image_from_artifact.sh
@@ -14,8 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
 ROOT_DIRECTORY=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../.." )
 APP_ARTIFACT_NAME=$(cat $ROOT_DIRECTORY/app/AppManifest.json | jq -r .name | tr -d '"')
 APP_NAME_LOWERCASE=$(echo $APP_ARTIFACT_NAME | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
   build-image:
     name: "Building image (${{ inputs.app_name }})"
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.1
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.2
     env:
       APP_NAME: ${{ inputs.app_name }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.1
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.2
     name: Run unit tests and linters
 
     steps:

--- a/.github/workflows/ensure-lifecycle.yml
+++ b/.github/workflows/ensure-lifecycle.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   check-sync:
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.1
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.2
     name: Are files in sync?
 
     steps:

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -6,7 +6,7 @@
         },
         {
             "name": "devenv-github-workflows",
-            "version": "v3.1.0"
+            "version": "v4.0.0"
         },
         {
             "name": "devenv-github-templates",
@@ -14,7 +14,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v1.2.1"
+            "version": "v1.4.0"
         }
     ],
     "variables": {
@@ -23,6 +23,5 @@
         "appManifestPath": "app/AppManifest.json",
         "githubRepoId": "eclipse-velocitas/vehicle-app-python-template",
         "generatedModelPath": "./gen/vehicle_model"
-    },
-    "cliVersion": "v0.5.5"
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -183,6 +183,20 @@
 			"problemMatcher": []
 		},
 		{
+			"label": "(Re-)generate gRPC SDKs",
+			"detail": "(Re-)generates all auto-generated gRPC SDKs used by the app",
+			"type": "shell",
+			"command": "velocitas exec grpc-interface-support generate-sdk",
+			"group": "none",
+			"presentation": {
+				"reveal": "always",
+				"panel": "dedicated",
+				"clear": true,
+				"close": false
+			},
+			"problemMatcher": [ ]
+		},
+		{
 			"label": "Kanto Runtime - Up",
 			"detail": "Starts up the Kanto runtime.",
 			"type": "shell",

--- a/app/requirements-links.txt
+++ b/app/requirements-links.txt
@@ -1,1 +1,0 @@
-git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@v0.11.0

--- a/app/requirements-velocitas.txt
+++ b/app/requirements-velocitas.txt
@@ -1,0 +1,1 @@
+velocitas-sdk==0.12.1

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -19,13 +19,13 @@ import json
 import logging
 import signal
 
-from sdv.util.log import (  # type: ignore
+from vehicle import Vehicle, vehicle  # type: ignore
+from velocitas_sdk.util.log import (  # type: ignore
     get_opentelemetry_log_factory,
     get_opentelemetry_log_format,
 )
-from sdv.vdb.reply import DataPointReply
-from sdv.vehicle_app import VehicleApp, subscribe_topic
-from vehicle import Vehicle, vehicle  # type: ignore
+from velocitas_sdk.vdb.reply import DataPointReply
+from velocitas_sdk.vehicle_app import VehicleApp, subscribe_topic
 
 # Configure the VehicleApp logger with the necessary log config and level.
 logging.setLogRecordFactory(get_opentelemetry_log_factory())

--- a/app/tests/integration/integration_test.py
+++ b/app/tests/integration/integration_test.py
@@ -15,8 +15,8 @@
 import json
 
 import pytest
-from sdv.test.inttesthelper import IntTestHelper
-from sdv.test.mqtt_util import MqttClient
+from velocitas_sdk.test.inttesthelper import IntTestHelper
+from velocitas_sdk.test.mqtt_util import MqttClient
 
 # GET_SPEED_REQUEST_TOPIC = "sampleapp/getSpeed"
 # GET_SPEED_RESPONSE_TOPIC = "sampleapp/getSpeed/response"

--- a/app/tests/unit/test_run.py
+++ b/app/tests/unit/test_run.py
@@ -18,9 +18,9 @@ from unittest import mock
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
-from sdv.vdb.types import TypedDataPointResult
-from sdv.vehicle_app import VehicleApp
 from vehicle import vehicle  # type: ignore
+from velocitas_sdk.vdb.types import TypedDataPointResult
+from velocitas_sdk.vehicle_app import VehicleApp
 
 MOCKED_SPEED = 0.0
 


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

PR adds the ability to use `grpc-interface` functional interfaces in your app manifest. See: https://eclipse.dev/velocitas/docs/concepts/development_model/vehicle_app_manifest/interfaces/grpc_interface/

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
