### PR TITLE
[Fix] Bring local-runtime's app terminal to front

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,8 +49,8 @@
 			"command": "velocitas exec runtime-local up",
 			"group": "none",
 			"presentation": {
-				"reveal": "always",
-				"panel": "dedicated"
+				"panel": "dedicated",
+				"clear": true,
 			},
 			"problemMatcher": []
 		},
@@ -62,8 +62,8 @@
 				"velocitas exec runtime-local run-vehicle-app --dapr-app-id vehicleapp --dapr-app-port 50008 python3 ${workspaceFolder}/app/src/main.py"
 			],
 			"presentation": {
-				"close": true,
-				"reveal": "never"
+				"panel": "dedicated",
+				"clear": true,
 			},
 			"problemMatcher": []
 		},
@@ -72,8 +72,11 @@
 			"detail": "Starts the VehicleDataBroker CLI",
 			"type": "shell",
 			"command": "velocitas exec runtime-local run-vehicledatabroker-cli",
+			"presentation": {
+				"panel": "dedicated",
+				"clear": true,
+			},
 			"group": "none",
-			"isBackground": false,
 			"problemMatcher": []
 		},
 		{
@@ -82,7 +85,6 @@
 			"type": "shell",
 			"command": "pre-commit run --show-diff-on-failure --color=always --all-files",
 			"group": "none",
-			"isBackground": false,
 			"problemMatcher": []
 		},
 		{


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

Makes sure if using vscode task "Local Runtime - Run VehicleApp" that the opened terminal is brought to front

## Issue ticket number and link

none

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
