### PR TITLE
Make black and flake8 compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,8 @@
 [flake8]
 max-line-length = 88
 max-complexity = 18
-select = B,C,E,F,W,T4,B9,B950
+extend-ignore = E203
+select = B,C,E,F,T4,B9,B950
 
 [mypy]
 python_version = 3.10


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description
This PR fixes compatibility between black and flake8 settings.

<!--
Please explain the changes you've made.
-->

## Issue ticket number and link
https://github.com/orgs/eclipse-velocitas/projects/7?pane=issue&itemId=37837378
<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
