### PR TITLE
Rename component vehicle-model-lifecycle to vehicle-signal-interface

### DIFF
--- a/.velocitas.json
+++ b/.velocitas.json
@@ -14,7 +14,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v1.4.7"
+            "version": "v1.5.1"
         }
     ],
     "variables": {

--- a/.vscode/scripts/import-example-app.sh
+++ b/.vscode/scripts/import-example-app.sh
@@ -40,8 +40,8 @@ else
   done
 
   # Generate model referenced by imported example
-  velocitas exec vehicle-model-lifecycle download-vspec
-  velocitas exec vehicle-model-lifecycle generate-model
+  velocitas exec vehicle-signal-interface download-vspec
+  velocitas exec vehicle-signal-interface generate-model
 
   echo "#######################################################"
   echo "Successfully imported $@"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -186,7 +186,7 @@
 			"label": "(Re-)generate vehicle model",
 			"detail": "(Re-)generates the vehicle model from source files specified in the AppManifest.",
 			"type": "shell",
-			"command": "velocitas exec vehicle-model-lifecycle download-vspec && velocitas exec vehicle-model-lifecycle generate-model",
+			"command": "velocitas exec vehicle-signal-interface download-vspec && velocitas exec vehicle-signal-interface generate-model",
 			"group": "none",
 			"presentation": {
 				"reveal": "always",


### PR DESCRIPTION
This PR renames the component call vehicle-model-lifecycle to vehicle-signal-interface

could only be merged after https://github.com/eclipse-velocitas/devenv-devcontainer-setup/pull/55 and new tag