### PR TITLE
Add default unit_src to app manifest for interface

### DIFF
--- a/app/AppManifest.json
+++ b/app/AppManifest.json
@@ -6,7 +6,9 @@
             "type": "vehicle-signal-interface",
             "config": {
                 "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
-                "unit_src": "https://github.com/COVESA/vehicle_signal_specification/blob/v4.0/spec/units.yaml",
+                "unit_src": [
+                    "https://github.com/COVESA/vehicle_signal_specification/blob/v4.0/spec/units.yaml"
+                ]
                 "datapoints": {
                     "required": [
                         {

--- a/app/AppManifest.json
+++ b/app/AppManifest.json
@@ -6,6 +6,7 @@
             "type": "vehicle-signal-interface",
             "config": {
                 "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
+                "unit_src": "https://github.com/COVESA/vehicle_signal_specification/blob/v4.0/spec/units.yaml",
                 "datapoints": {
                     "required": [
                         {


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description
This adds the ability to specify a list of unit files for model generation with vss-tools. It is needed to support VSS 4.0.
<!--
Please explain the changes you've made.
-->

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
