### PR TITLE
Add necessary permissions for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
   release:
     types: [published, edited]
 
+# Needed if GITHUB_TOKEN by default do not have right to create release
+permissions:
+  contents: write
+  packages: write
+
 jobs:
 
   get-app-name:
@@ -163,7 +168,7 @@ jobs:
           templatePath: ./.github/actions/templates
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "0.89.4"
           extended: true
@@ -243,7 +248,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GH Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{github.workspace}}/hugo/public

--- a/.velocitas-lock.json
+++ b/.velocitas-lock.json
@@ -1,7 +1,7 @@
 {
     "packages": {
         "devenv-runtimes": "v4.0.1",
-        "devenv-github-workflows": "v6.0.2",
+        "devenv-github-workflows": "v6.0.3",
         "devenv-github-templates": "v1.0.5",
         "devenv-devcontainer-setup": "v2.4.0"
     }

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -1,7 +1,7 @@
 {
     "packages": {
         "devenv-runtimes": "v4.0.1",
-        "devenv-github-workflows": "v6.0.2",
+        "devenv-github-workflows": "v6.0.3",
         "devenv-github-templates": "v1.0.5",
         "devenv-devcontainer-setup": "v2.4.0"
     },

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -81,7 +81,7 @@
 |haya14busa/action-cond|v1|MIT License|
 |irongut/CodeCoverageSummary|v1.3.0|MIT License|
 |mikepenz/action-junit-report|v4|Apache License 2.0|
-|peaceiris/actions-gh-pages|v3|MIT License|
-|peaceiris/actions-hugo|v2|MIT License|
+|peaceiris/actions-gh-pages|v4|MIT License|
+|peaceiris/actions-hugo|v3|MIT License|
 |pre-commit/action|v3.0.0|MIT License|
 |softprops/action-gh-release|v2|MIT License|


### PR DESCRIPTION
A Github default token does not not have content/package permission


.velocitas.json updated manually
The others updated automatically by

- velocitas init
- velocitas sync

Notice taken from build

Fixes #240
Fixes #242

Tested in https://github.com/erikbosch/vehicle-example-app2/actions/workflows/release.yml
